### PR TITLE
Entrypoint shebang fix

### DIFF
--- a/2025-HPDC/docker/init-entrypoint.sh
+++ b/2025-HPDC/docker/init-entrypoint.sh
@@ -1,9 +1,8 @@
+#!/usr/bin/env sh 
 # Copyright 2025 Lawrence Livermore National Security, LLC and other
 # Benchpark developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: Apache-2.0
-
-#!/usr/bin/env sh 
 
 # NOTE: this script runs as root
 

--- a/2025-HPDC/docker/spawn-entrypoint.sh
+++ b/2025-HPDC/docker/spawn-entrypoint.sh
@@ -1,8 +1,7 @@
+#!/usr/bin/env bash
 # Copyright 2025 Lawrence Livermore National Security, LLC and other
 # Benchpark developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: Apache-2.0
-
-#!/usr/bin/env bash
 
 /opt/global_py_venv/bin/jupyterhub-singleuser


### PR DESCRIPTION
## Description

I made a bit of a mistake when adding license headers to some of the files. More specifically, I put the license header before the shebang in several shell scripts. As a result, those scripts cannot be properly run, leading to errors.

This PR fixes this.

## Checklist
- [X] If creating a new version of the tutorial, create a new directory at the root of the repository with the relevant name
- [X] Ensure all Docker-related material except for tutorial contents goes in a `docker` subdirectory
- [X] Update `github_ci_matrix.json` with (1) the tag you will eventually use for the tutorial Docker images (place in the `"tag"` field) and (2) the name of the directory for your version of the tutorial (place in the `"tutorial_dir"` field)