### PR TITLE
Updates the Docker images so that users run under Flux

### DIFF
--- a/2025-HPDC/docker/Dockerfile.benchpark
+++ b/2025-HPDC/docker/Dockerfile.benchpark
@@ -37,15 +37,9 @@ USER root
 RUN . /opt/global_py_venv/bin/activate && \
     python3 -m pip install -r ${HOME}/benchpark/requirements.txt
 
-RUN echo 'export PATH=/usr/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo '. /opt/global_py_venv/bin/activate' >> ${HOME}/.bashrc && \
-    echo 'export LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=${HOME}/benchpark/bin:$PATH' >> ${HOME}/.bashrc
+RUN echo 'export PATH=${HOME}/benchpark/bin:$PATH' >> ${HOME}/.bashrc
 
-RUN echo 'export PATH=/usr/bin:$PATH' >> ${HOME}/.bash_profile && \
-    echo '. /opt/global_py_venv/bin/activate' >> ${HOME}/.bash_profile && \
-    echo 'export LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH' >> ${HOME}/.bash_profile && \
-    echo 'export PATH=${HOME}/benchpark/bin:$PATH' >> ${HOME}/.bash_profile
+RUN echo 'export PATH=${HOME}/benchpark/bin:$PATH' >> ${HOME}/.bash_profile
 
 RUN chmod -R 777 ~/ ${HOME}
 

--- a/2025-HPDC/docker/Dockerfile.caliper
+++ b/2025-HPDC/docker/Dockerfile.caliper
@@ -3,11 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:noble
+# FROM ubuntu:noble
+FROM fluxrm/flux-sched:noble
 
 # ubuntu:noble added a new 'ubuntu' user in the container.
 # Get rid of it!
-RUN userdel -r ubuntu
+# RUN userdel -r ubuntu
 
 USER root
 

--- a/2025-HPDC/docker/Dockerfile.caliper
+++ b/2025-HPDC/docker/Dockerfile.caliper
@@ -25,10 +25,13 @@ RUN apt-get update && \
     python3-dev \
     python3-pip \
     python3-venv \
-    openmpi-bin \
-    openmpi-common \
-    libopenmpi-dev \
     git \
+    # NOTE: the flux-sched image already pulls and builds MPICH 4.2.2
+    #       WITHOUT PMIx support (this is important because PMIx is a pain, and
+    #       requires extra setup with Flux).
+    # openmpi-bin \
+    # openmpi-common \
+    # libopenmpi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 SHELL [ "/bin/bash", "-c" ]
@@ -98,12 +101,26 @@ RUN adduser \
     --force-badname \
     ${NB_USER}
 
+# NOTE: this should NEVER be uncommented by the time we push to GHCR
+RUN adduser ${NB_USER} sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 RUN chmod -R 777 ~/ ${HOME}
 
 ENV SHELL=/usr/bin/bash
 
 RUN mkdir -p ${HOME}/.local/share && \
     chmod 777 ${HOME}/.local/share
+
+RUN echo $(flux env) 
+
+RUN echo 'export PATH=/usr/bin:$PATH' >> ${HOME}/.bashrc && \
+    echo '. /opt/global_py_venv/bin/activate' >> ${HOME}/.bashrc && \
+    echo 'export LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH' >> ${HOME}/.bashrc
+
+RUN echo 'export PATH=/usr/bin:$PATH' >> ${HOME}/.bash_profile && \
+    echo '. /opt/global_py_venv/bin/activate' >> ${HOME}/.bash_profile && \
+    echo 'export LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH' >> ${HOME}/.bash_profile
 
 USER ${NB_USER}
 WORKDIR ${HOME}

--- a/2025-HPDC/docker/Dockerfile.spawn
+++ b/2025-HPDC/docker/Dockerfile.spawn
@@ -40,6 +40,8 @@ RUN chmod 777 /entrypoint.sh
 RUN chmod 777 /local-entrypoint.sh
 
 USER ${NB_USER}
+ENV SHELL=/usr/bin/bash
+ENV FLUX_URI_RESOLVE_LOCAL=t
 
 RUN git clone https://github.com/LLNL/thicket-tutorial.git ${HOME}/thicket-tutorial && \
     cd ${HOME}/thicket-tutorial && \
@@ -51,4 +53,4 @@ RUN git clone https://github.com/LLNL/thicket-tutorial.git ${HOME}/thicket-tutor
 EXPOSE 8888
 ENTRYPOINT [ "tini", "--" ]
 
-CMD ["jupyter", "lab"]
+CMD ["flux", "start", "jupyter", "lab"]

--- a/2025-HPDC/docker/spawn-entrypoint.sh
+++ b/2025-HPDC/docker/spawn-entrypoint.sh
@@ -4,4 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-/opt/global_py_venv/bin/jupyterhub-singleuser
+num_cores_per_node=2
+total_num_cores=$(nproc --all)
+num_brokers=$(( $total_num_cores / $num_cores_per_node ))
+
+/usr/bin/mpiexec.hydra -n $num_brokers -bind-to core:$num_cores_per_node /usr/bin/flux start /opt/global_py_venv/bin/jupyterhub-singleuser

--- a/2025-HPDC/docker/spawn-local-entrypoint.sh
+++ b/2025-HPDC/docker/spawn-local-entrypoint.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-/opt/global_py_venv/bin/jupyter-lab --ip=0.0.0.0
+num_cores_per_node=2
+total_num_cores=$(nproc --all)
+num_brokers=$(( $total_num_cores / $num_cores_per_node ))
+
+/usr/bin/mpiexec.hydra -n $num_brokers -bind-to core:$num_cores_per_node /usr/bin/flux start /opt/global_py_venv/bin/jupyter-lab --ip=0.0.0.0


### PR DESCRIPTION
## Description

This PR adds Flux to the Docker stack by basing the Caliper image on the `fluxrm/flux-sched:noble` image. It also makes it so that each user's Jupyter instance is deployed under Flux. Instead of using Flux's `--test-size` parameter to emulate multiple nodes (which is what Flux does for its tutorial), I use `mpiexec.hydra` to spawn a number of brokers equal to "floor(num_cores / 2)".

## Checklist
- [X] Ensure all Docker-related material except for tutorial contents goes in a `docker` subdirectory
- [X] Update `github_ci_matrix.json` with (1) the tag you will eventually use for the tutorial Docker images (place in the `"tag"` field) and (2) the name of the directory for your version of the tutorial (place in the `"tutorial_dir"` field)