### PR TITLE
Fixes CSIDriver URL across all infrastructure

### DIFF
--- a/2025-HPDC/infrastructure/test-c7i-24xlarge/config.toml
+++ b/2025-HPDC/infrastructure/test-c7i-24xlarge/config.toml
@@ -50,5 +50,5 @@ init_image_entrypoint = "/entrypoint.sh"
 [aws."utility scripts"]
 tutorial_name = "hpdc-2025-c7i-24xlarge"
 jupyterhub_helm_version = "4.2.0"
-ebs_csidriver_version = "1.45.0"
+ebs_csidriver_version = "v1.45.0"
 ebs_storage_type = "gp3"

--- a/2025-HPDC/infrastructure/test-c7i-24xlarge/configure_kubernetes.sh
+++ b/2025-HPDC/infrastructure/test-c7i-24xlarge/configure_kubernetes.sh
@@ -10,7 +10,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
 fi
 
 echo "Configuring the Cluster Autoscaler:"
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.45.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=v1.45.0"
 kubectl apply -f ./cluster-autoscaler.yaml
 echo ""
 echo "Configuring the Storage Class:"

--- a/2025-HPDC/infrastructure/test-c7i-24xlarge/configure_kubernetes.sh
+++ b/2025-HPDC/infrastructure/test-c7i-24xlarge/configure_kubernetes.sh
@@ -10,7 +10,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
 fi
 
 echo "Configuring the Cluster Autoscaler:"
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=1.45.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.45.0"
 kubectl apply -f ./cluster-autoscaler.yaml
 echo ""
 echo "Configuring the Storage Class:"

--- a/2025-HPDC/infrastructure/test-c7i-48xlarge/config.toml
+++ b/2025-HPDC/infrastructure/test-c7i-48xlarge/config.toml
@@ -50,5 +50,5 @@ init_image_entrypoint = "/entrypoint.sh"
 [aws."utility scripts"]
 tutorial_name = "hpdc-2025-c7i-48xlarge"
 jupyterhub_helm_version = "4.2.0"
-ebs_csidriver_version = "1.45.0"
+ebs_csidriver_version = "v1.45.0"
 ebs_storage_type = "gp3"

--- a/2025-HPDC/infrastructure/test-c7i-48xlarge/configure_kubernetes.sh
+++ b/2025-HPDC/infrastructure/test-c7i-48xlarge/configure_kubernetes.sh
@@ -10,7 +10,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
 fi
 
 echo "Configuring the Cluster Autoscaler:"
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.45.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=v1.45.0"
 kubectl apply -f ./cluster-autoscaler.yaml
 echo ""
 echo "Configuring the Storage Class:"

--- a/2025-HPDC/infrastructure/test-c7i-48xlarge/configure_kubernetes.sh
+++ b/2025-HPDC/infrastructure/test-c7i-48xlarge/configure_kubernetes.sh
@@ -10,7 +10,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
 fi
 
 echo "Configuring the Cluster Autoscaler:"
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=1.45.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.45.0"
 kubectl apply -f ./cluster-autoscaler.yaml
 echo ""
 echo "Configuring the Storage Class:"

--- a/2025-HPDC/infrastructure/test-c7i-metal-24xl/config.toml
+++ b/2025-HPDC/infrastructure/test-c7i-metal-24xl/config.toml
@@ -50,5 +50,5 @@ init_image_entrypoint = "/entrypoint.sh"
 [aws."utility scripts"]
 tutorial_name = "hpdc-2025-c7i-metal-24xl"
 jupyterhub_helm_version = "4.2.0"
-ebs_csidriver_version = "1.45.0"
+ebs_csidriver_version = "v1.45.0"
 ebs_storage_type = "gp3"

--- a/2025-HPDC/infrastructure/test-c7i-metal-24xl/configure_kubernetes.sh
+++ b/2025-HPDC/infrastructure/test-c7i-metal-24xl/configure_kubernetes.sh
@@ -10,7 +10,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
 fi
 
 echo "Configuring the Cluster Autoscaler:"
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.45.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=v1.45.0"
 kubectl apply -f ./cluster-autoscaler.yaml
 echo ""
 echo "Configuring the Storage Class:"

--- a/2025-HPDC/infrastructure/test-c7i-metal-24xl/configure_kubernetes.sh
+++ b/2025-HPDC/infrastructure/test-c7i-metal-24xl/configure_kubernetes.sh
@@ -10,7 +10,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
 fi
 
 echo "Configuring the Cluster Autoscaler:"
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=1.45.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.45.0"
 kubectl apply -f ./cluster-autoscaler.yaml
 echo ""
 echo "Configuring the Storage Class:"

--- a/2025-HPDC/infrastructure/test-c7i-metal-48xl/config.toml
+++ b/2025-HPDC/infrastructure/test-c7i-metal-48xl/config.toml
@@ -50,5 +50,5 @@ init_image_entrypoint = "/entrypoint.sh"
 [aws."utility scripts"]
 tutorial_name = "hpdc-2025-c7i-metal-48xl"
 jupyterhub_helm_version = "4.2.0"
-ebs_csidriver_version = "1.45.0"
+ebs_csidriver_version = "v1.45.0"
 ebs_storage_type = "gp3"

--- a/2025-HPDC/infrastructure/test-c7i-metal-48xl/configure_kubernetes.sh
+++ b/2025-HPDC/infrastructure/test-c7i-metal-48xl/configure_kubernetes.sh
@@ -10,7 +10,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
 fi
 
 echo "Configuring the Cluster Autoscaler:"
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.45.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=v1.45.0"
 kubectl apply -f ./cluster-autoscaler.yaml
 echo ""
 echo "Configuring the Storage Class:"

--- a/2025-HPDC/infrastructure/test-c7i-metal-48xl/configure_kubernetes.sh
+++ b/2025-HPDC/infrastructure/test-c7i-metal-48xl/configure_kubernetes.sh
@@ -10,7 +10,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
 fi
 
 echo "Configuring the Cluster Autoscaler:"
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=1.45.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.45.0"
 kubectl apply -f ./cluster-autoscaler.yaml
 echo ""
 echo "Configuring the Storage Class:"


### PR DESCRIPTION
## Description

When I last generated the infrastructure, Jinja didn't correctly prefix the CSIDriver version with "release-", which causes things to fail. This PR fixes this.