### PR TITLE
Post-Jammy Downgrade Tweaks

### DIFF
--- a/2025-HPDC/docker/Dockerfile.benchpark
+++ b/2025-HPDC/docker/Dockerfile.benchpark
@@ -53,6 +53,5 @@ RUN mkdir -p ${HOME}/.local/share && \
 USER ${NB_USER}
 
 # Run this to trigger bootstrap
-# TODO change to new benchpark bootstrap command
 RUN . /opt/global_py_venv/bin/activate && \
-    ${HOME}/benchpark/bin/benchpark audit -h
+    ${HOME}/benchpark/bin/benchpark bootstrap

--- a/2025-HPDC/docker/Dockerfile.caliper
+++ b/2025-HPDC/docker/Dockerfile.caliper
@@ -26,6 +26,11 @@ RUN apt-get update && \
     python3-pip \
     python3-venv \
     git \
+    util-linux \
+    less \
+    htop \
+    zip \
+    unzip \
     # NOTE: the flux-sched image already pulls and builds MPICH 4.2.2
     #       WITHOUT PMIx support (this is important because PMIx is a pain, and
     #       requires extra setup with Flux).

--- a/2025-HPDC/docker/Dockerfile.spawn
+++ b/2025-HPDC/docker/Dockerfile.spawn
@@ -16,8 +16,7 @@ RUN apt-get update && \
     ca-certificates \
     dnsutils \
     iputils-ping \
-    tini \
-    && rm -rf /var/lib/apt/lists/*
+    tini
 
 SHELL [ "/bin/bash", "-c" ]
 
@@ -30,6 +29,14 @@ RUN . /opt/global_py_venv/bin/activate && \
     # Covered in requirements.txt, so shouldn't be needed here
     # python3 -m pip install ipython==7.34.0 ipykernel==6.25.1 && \
     python3 -m IPython kernel install
+
+COPY ./docker/kitware-archive.sh /tmp
+
+RUN /tmp/kitware-archive.sh && \
+    apt install -y cmake && \
+    which cmake && \
+    cmake --version && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN chmod -R 777 ~/ ${HOME}
 

--- a/2025-HPDC/docker/kitware-archive.sh
+++ b/2025-HPDC/docker/kitware-archive.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+set -eu
+
+help() {
+  echo "Usage: $0 [--release <ubuntu-release>] [--rc]" > /dev/stderr
+}
+
+doing=
+rc=
+release=
+help=
+for opt in "$@"
+do
+  case "${doing}" in
+  release)
+    release="${opt}"
+    doing=
+    ;;
+  "")
+    case "${opt}" in
+    --rc)
+      rc=1
+      ;;
+    --release)
+      doing=release
+      ;;
+    --help)
+      help=1
+      ;;
+    esac
+    ;;
+  esac
+done
+
+if [ -n "${doing}" ]
+then
+  echo "--${doing} option given no argument." > /dev/stderr
+  echo > /dev/stderr
+  help
+  exit 1
+fi
+
+if [ -n "${help}" ]
+then
+  help
+  exit
+fi
+
+if [ -z "${release}" ]
+then
+  unset UBUNTU_CODENAME
+  . /etc/os-release
+
+  if [ -z "${UBUNTU_CODENAME+x}" ]
+  then
+    echo "This is not an Ubuntu system. Aborting." > /dev/stderr
+    exit 1
+  fi
+
+  release="${UBUNTU_CODENAME}"
+fi
+
+case "${release}" in
+noble|jammy|focal)
+  packages=
+  keyring_packages="ca-certificates gpg wget"
+  ;;
+*)
+  echo "Only Ubuntu Noble (24.04), Jammy (22.04), and Focal (20.04) are supported. Aborting." > /dev/stderr
+  exit 1
+  ;;
+esac
+
+get_keyring=
+if [ ! -f /usr/share/doc/kitware-archive-keyring/copyright ]
+then
+  packages="${packages} ${keyring_packages}"
+  get_keyring=1
+fi
+
+# Start the real work
+set -x
+
+apt-get update
+# shellcheck disable=SC2086
+apt-get install -y ${packages}
+
+test -n "${get_keyring}" && (wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg)
+
+echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${release} main" > /etc/apt/sources.list.d/kitware.list
+if [ -n "${rc}" ]
+then
+  echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${release}-rc main" >> /etc/apt/sources.list.d/kitware.list
+fi
+
+apt-get update
+test -n "${get_keyring}" && rm /usr/share/keyrings/kitware-archive-keyring.gpg
+apt-get install -y kitware-archive-keyring

--- a/2025-HPDC/docker/spawn-entrypoint.sh
+++ b/2025-HPDC/docker/spawn-entrypoint.sh
@@ -4,8 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-num_cores_per_node=2
-total_num_cores=$(nproc --all)
-num_brokers=$(( $total_num_cores / $num_cores_per_node ))
+# TODO uncomment if we want multiple "nodes"
+# num_cores_per_node=2
+# total_num_cores=$(nproc --all)
+# num_brokers=$(( $total_num_cores / $num_cores_per_node ))
+# /usr/bin/mpiexec.hydra -n $num_brokers -bind-to core:$num_cores_per_node /usr/bin/flux start /opt/global_py_venv/bin/jupyterhub-singleuser
 
-/usr/bin/mpiexec.hydra -n $num_brokers -bind-to core:$num_cores_per_node /usr/bin/flux start /opt/global_py_venv/bin/jupyterhub-singleuser
+# NOTE: use this if we only want a single "node"
+/usr/bin/flux start /opt/global_py_venv/bin/jupyterhub-singleuser

--- a/2025-HPDC/docker/spawn-local-entrypoint.sh
+++ b/2025-HPDC/docker/spawn-local-entrypoint.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-num_cores_per_node=2
-total_num_cores=$(nproc --all)
-num_brokers=$(( $total_num_cores / $num_cores_per_node ))
+# TODO uncomment if we want multiple "nodes"
+# num_cores_per_node=2
+# total_num_cores=$(nproc --all)
+# num_brokers=$(( $total_num_cores / $num_cores_per_node ))
+# /usr/bin/mpiexec.hydra -n $num_brokers -bind-to core:$num_cores_per_node /usr/bin/flux start /opt/global_py_venv/bin/jupyter-lab --ip=0.0.0.0
 
-/usr/bin/mpiexec.hydra -n $num_brokers -bind-to core:$num_cores_per_node /usr/bin/flux start /opt/global_py_venv/bin/jupyter-lab --ip=0.0.0.0
+# NOTE: do this if we only want a single "node"
+/usr/bin/flux start /opt/global_py_venv/bin/jupyter-lab --ip=0.0.0.0


### PR DESCRIPTION
## Description

This PR performs the following tweaks to the Dockerfiles after the Ubuntu Jammy downgrade:
* Uses the Kitware apt repo to pull CMake 4.0.2 since the normal CMake installed by apt is too old
* Changes the use of `benchpark audit -h` for bootstrapping out for `benchpark bootstrap`
* Adds several new utilities, including `less`, `more`, and `htop`
* Changes the entrypoint scripts for the spawn image to only let Flux see a single "node"