### PR TITLE
Updates to thicket and benchpark

### DIFF
--- a/2025-HPDC/docker/Dockerfile.benchpark
+++ b/2025-HPDC/docker/Dockerfile.benchpark
@@ -32,7 +32,7 @@ USER ${NB_USER}
 
 RUN git clone https://github.com/LLNL/benchpark.git ${HOME}/benchpark && \
     cd ${HOME}/benchpark && \
-    git checkout -b develop-2025-07-08 develop-2025-07-08 && \
+    git checkout -b develop-2025-07-14 develop-2025-07-14 && \
     git submodule update --init --recursive
 
 USER root

--- a/2025-HPDC/docker/Dockerfile.spawn
+++ b/2025-HPDC/docker/Dockerfile.spawn
@@ -83,8 +83,10 @@ RUN cmake \
 # rm -rf /tmp/build-xsbench
 
 COPY ./tutorial-code/caliper-tutorial/tutorial ${HOME}/caliper-tutorial/
-COPY ./tutorial-code/thicket-tutorial/data/ ${HOME}/thicket-tutorial/data/
-COPY ./tutorial-code/thicket-tutorial/notebooks ${HOME}/thicket-tutorial/notebooks/
+COPY ./tutorial-code/thicket-tutorial/data/lassen ${HOME}/thicket-tutorial/data/lassen
+COPY ./tutorial-code/thicket-tutorial/data/quartz ${HOME}/thicket-tutorial/data/quartz
+COPY ./tutorial-code/thicket-tutorial/notebooks/01_thicket_tutorial.ipynb ${HOME}/thicket-tutorial/notebooks/01_thicket_tutorial.ipynb
+COPY ./tutorial-code/thicket-tutorial/notebooks/02_thicket_rajaperf_clustering.ipynb ${HOME}/thicket-tutorial/notebooks/02_thicket_rajaperf_clustering.ipynb
 COPY ./tutorial-code/thicket-tutorial/LICENSE ${HOME}/thicket-tutorial
 
 COPY tutorial-code/system-description/aws-tutorial ${HOME}/benchpark/systems/aws-tutorial


### PR DESCRIPTION
- updates benchpark tag to `develop-2025-07-14`
- copies specific thicket notebook (01_thicket_tutorial.ipynb) and needed data