### PR TITLE
temporarily comment out copying of thicket-tutorial license file

### DIFF
--- a/2025-HPCIC/docker/Dockerfile.spawn
+++ b/2025-HPCIC/docker/Dockerfile.spawn
@@ -88,7 +88,7 @@ COPY ./tutorial-code/thicket-tutorial/data/lassen ${HOME}/thicket-tutorial/data/
 COPY ./tutorial-code/thicket-tutorial/data/quartz ${HOME}/thicket-tutorial/data/quartz
 COPY ./tutorial-code/thicket-tutorial/notebooks/01_thicket_tutorial.ipynb ${HOME}/thicket-tutorial/notebooks/01_thicket_tutorial.ipynb
 COPY ./tutorial-code/thicket-tutorial/notebooks/02_thicket_rajaperf_clustering.ipynb ${HOME}/thicket-tutorial/notebooks/02_thicket_rajaperf_clustering.ipynb
-COPY ./tutorial-code/thicket-tutorial/LICENSE ${HOME}/thicket-tutorial
+#COPY ./tutorial-code/thicket-tutorial/LICENSE ${HOME}/thicket-tutorial
 
 COPY tutorial-code/system-description/aws-tutorial ${HOME}/benchpark/systems/aws-tutorial
 COPY tutorial-code/system-description/AWS_Tutorial-c7i-EFA ${HOME}/benchpark/systems/all_hardware_descriptions/AWS_Tutorial-c7i-EFA


### PR DESCRIPTION
 container builds to fail