### PR TITLE
Cleanup for dry run

### DIFF
--- a/2025-HPCIC/infrastructure/dry-run/README.md
+++ b/2025-HPCIC/infrastructure/dry-run/README.md
@@ -1,6 +1,6 @@
-# Deploy hpcic-2025-tutorial to AWS Elastic Kubernetes Service (EKS)
+# Deploy perftools-hpcic-2025-dry-run to AWS Elastic Kubernetes Service (EKS)
 
-These config files and scripts can be used to deploy the hpcic-2025-tutorial tutorial to EKS.
+These config files and scripts can be used to deploy the perftools-hpcic-2025-dry-run tutorial to EKS.
 
 The sections below walk you through the steps to deploying your cluster. All commands in these
 sections should be run from the same directory as this README.

--- a/2025-HPCIC/infrastructure/dry-run/cleanup.sh
+++ b/2025-HPCIC/infrastructure/dry-run/cleanup.sh
@@ -27,7 +27,7 @@ fi
 # if the JupyterHub deployment failed or was previously torn down
 set +e
 echo "Tearing down JupyterHub and uninstalling everything related to Helm:"
-helm uninstall hpcic-2025-tutorial-jupyter
+helm uninstall perftools-hpcic-2025-dry-run-jupyter
 set -e
 
 echo ""

--- a/2025-HPCIC/infrastructure/dry-run/cluster-autoscaler.yaml
+++ b/2025-HPCIC/infrastructure/dry-run/cluster-autoscaler.yaml
@@ -245,7 +245,7 @@ spec:
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
             - --expander=least-waste
-            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/hpcic-2025-tutorial
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/perftools-hpcic-2025-dry-run
           volumeMounts:
             # Mount the CA SSL/TLS certificates into the container
             - name: ssl-certs

--- a/2025-HPCIC/infrastructure/dry-run/config.toml
+++ b/2025-HPCIC/infrastructure/dry-run/config.toml
@@ -1,7 +1,7 @@
-tutorial_name = "hpcic-2025-dry-run"
+tutorial_name = "perftools-hpcic-2025-dry-run"
 
 [aws.eksctl]
-cluster_name = "hpcic-2025-dry-run"
+cluster_name = "perftools-hpcic-2025-dry-run"
 cluster_deployment_region = "us-west-1"
 cluster_availability_zones = [
     "us-west-1a",

--- a/2025-HPCIC/infrastructure/dry-run/deploy_jupyterhub.sh
+++ b/2025-HPCIC/infrastructure/dry-run/deploy_jupyterhub.sh
@@ -14,7 +14,7 @@ helm repo add jupyterhub https://hub.jupyter.org/helm-chart/
 helm repo update
 echo ""
 echo "Installing the Helm chart and deploying JupyterHub to EKS:"
-helm install hpcic-2025-tutorial-jupyter jupyterhub/jupyterhub --version 4.2.0 --values ./helm-config.yaml
+helm install perftools-hpcic-2025-dry-run-jupyter jupyterhub/jupyterhub --version 4.2.0 --values ./helm-config.yaml
 
 echo ""
 echo "Done deploying JupyterHub!"

--- a/2025-HPCIC/infrastructure/dry-run/eksctl-config.yaml
+++ b/2025-HPCIC/infrastructure/dry-run/eksctl-config.yaml
@@ -2,8 +2,8 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 # Define the name of the cluster and the deployment region
 metadata:
-  name: hpcic-2025-tutorial
-  region: us-east-1
+  name: perftools-hpcic-2025-dry-run
+  region: us-west-1
 
 # Create the IAM policies needed to enable the autoscaler and storage
 iam:
@@ -58,14 +58,14 @@ iam:
 
 # Specify the availability zone from which nodes will be obtained
 availabilityZones:
-- "us-east-1a"
-- "us-east-1b"
+- "us-west-1a"
+- "us-west-1c"
 
 
 # Define rules for nodegroups for each availability zone
 managedNodeGroups:
 
-  - name: node-group-us-east-1a
+  - name: node-group-us-west-1a
     # Set policies/permissions to autoscale
     iam:
       withAddonPolicies:
@@ -75,19 +75,19 @@ managedNodeGroups:
     # Size of storage volume for the availability zone, in gigabytes
     volumeSize: 30
     # Number of nodes to start with in this availability zone
-    desiredCapacity: 15
+    desiredCapacity: 2
     # Minimum number of nodes that will always be allocated in this availability zone
-    minSize: 15
+    minSize: 2
     # Maximum number of nodes that will every be allocated in this availability zone
-    maxSize: 100
+    maxSize: 8
     privateNetworking: true
     availabilityZones:
-      - us-east-1a
+      - us-west-1a
     tags:
       k8s.io/cluster-autoscaler/enabled: "true"
       k8s.io/cluster-autoscaler/jupyterhub: "owned"
 
-  - name: node-group-us-east-1b
+  - name: node-group-us-west-1c
     # Set policies/permissions to autoscale
     iam:
       withAddonPolicies:
@@ -97,14 +97,14 @@ managedNodeGroups:
     # Size of storage volume for the availability zone, in gigabytes
     volumeSize: 30
     # Number of nodes to start with in this availability zone
-    desiredCapacity: 15
+    desiredCapacity: 2
     # Minimum number of nodes that will always be allocated in this availability zone
-    minSize: 15
+    minSize: 2
     # Maximum number of nodes that will every be allocated in this availability zone
-    maxSize: 100
+    maxSize: 8
     privateNetworking: true
     availabilityZones:
-      - us-east-1b
+      - us-west-1c
     tags:
       k8s.io/cluster-autoscaler/enabled: "true"
       k8s.io/cluster-autoscaler/jupyterhub: "owned"

--- a/2025-HPCIC/infrastructure/dry-run/helm-config.yaml
+++ b/2025-HPCIC/infrastructure/dry-run/helm-config.yaml
@@ -6,7 +6,7 @@
 
 hub:
   # Maximum number of users with spawned JupyterLab environments (i.e., pods) at a time
-  concurrentSpawnLimit: 30
+  concurrentSpawnLimit: 14
   config:
     # Define a password for login
     DummyAuthenticator:
@@ -118,3 +118,4 @@ singleuser:
     extraVolumeMounts:
       - name: shm-volume
         mountPath: /dev/shm
+    

--- a/2025-HPCIC/infrastructure/dry-run/tear_down_jupyterhub.sh
+++ b/2025-HPCIC/infrastructure/dry-run/tear_down_jupyterhub.sh
@@ -9,7 +9,7 @@ if ! command -v helm >/dev/null 2>&1; then
     exit 1
 fi
 
-helm uninstall hpcic-2025-tutorial-jupyter
+helm uninstall perftools-hpcic-2025-dry-run-jupyter
 
 echo "Helm's JupyterHub deployment is torn down."
 echo "If any attendee pods are remaining, you can delete them with 'kubectl delete pod <pod_name>'"

--- a/2025-HPCIC/infrastructure/dry-run/update_jupyterhub_deployment.sh
+++ b/2025-HPCIC/infrastructure/dry-run/update_jupyterhub_deployment.sh
@@ -9,6 +9,6 @@ if ! command -v helm >/dev/null 2>&1; then
     exit 1
 fi
 
-helm upgrade hpcic-2025-tutorial-jupyter jupyterhub/jupyterhub  --values ./helm-config.yaml
+helm upgrade perftools-hpcic-2025-dry-run-jupyter jupyterhub/jupyterhub  --values ./helm-config.yaml
 
 echo "The JupyterHub deployment is updated!"


### PR DESCRIPTION
1) update thicket-tutorial submodule (revert change to first thicket notebook)
2) re-generate infrastructure files after updating config.toml using `hpcic-k8s-configure aws -l -c config.toml` (previously had copied 2025-HPDC/ and manually updated all files)