### PR TITLE
Updates eScience infrastructure to just use HPCIC images

### DIFF
--- a/2025-eScience/infrastructure/dry-run/config.toml
+++ b/2025-eScience/infrastructure/dry-run/config.toml
@@ -39,7 +39,7 @@ use_nginx = true
 hub_container_image = "jupyterhub/k8s-hub"
 hub_container_tag = "4.2.0"
 spawner_container_image = "ghcr.io/llnl/reproducible-benchmarking-spawn"
-spawner_container_tag = "escience-2025"
+spawner_container_tag = "hpcic-2025"
 spawner_image_entrypoint = "/entrypoint.sh 32"
 cpu_min = "32"
 cpu_max = "32"
@@ -47,7 +47,7 @@ mem_min = "64G"
 mem_max = "64G"
 provide_extra_shmem = true
 init_container_image = "ghcr.io/llnl/reproducible-benchmarking-init"
-init_container_tag = "escience-2025"
+init_container_tag = "hpcic-2025"
 init_image_entrypoint = "/entrypoint.sh"
 
 [aws."utility scripts"]

--- a/2025-eScience/infrastructure/dry-run/helm-config.yaml
+++ b/2025-eScience/infrastructure/dry-run/helm-config.yaml
@@ -64,7 +64,7 @@ singleuser:
   #   5) Copy any necessary local scripts or files and ensure proper permissions
   image:
     name: ghcr.io/llnl/reproducible-benchmarking-spawn
-    tag: "escience-2025"
+    tag: "hpcic-2025"
     pullPolicy: Always
   # Specify the minimum (i.e., guarantee) and maximum (i.e., limit) amount of resources per user
   cpu:
@@ -106,7 +106,7 @@ singleuser:
   #    chown -R 1000 /home/jovyan
   initContainers:
     - name: init-tutorial-service
-      image: ghcr.io/llnl/reproducible-benchmarking-init:escience-2025
+      image: ghcr.io/llnl/reproducible-benchmarking-init:hpcic-2025
       command: ["/entrypoint.sh"]
       imagePullPolicy: Always
   storage:

--- a/2025-eScience/infrastructure/production/config.toml
+++ b/2025-eScience/infrastructure/production/config.toml
@@ -39,7 +39,7 @@ use_nginx = true
 hub_container_image = "jupyterhub/k8s-hub"
 hub_container_tag = "4.2.0"
 spawner_container_image = "ghcr.io/llnl/reproducible-benchmarking-spawn"
-spawner_container_tag = "escience-2025"
+spawner_container_tag = "hpcic-2025"
 spawner_image_entrypoint = "/entrypoint.sh 32"
 cpu_min = "32"
 cpu_max = "32"
@@ -47,7 +47,7 @@ mem_min = "64G"
 mem_max = "64G"
 provide_extra_shmem = true
 init_container_image = "ghcr.io/llnl/reproducible-benchmarking-init"
-init_container_tag = "escience-2025"
+init_container_tag = "hpcic-2025"
 init_image_entrypoint = "/entrypoint.sh"
 
 [aws."utility scripts"]

--- a/2025-eScience/infrastructure/production/helm-config.yaml
+++ b/2025-eScience/infrastructure/production/helm-config.yaml
@@ -64,7 +64,7 @@ singleuser:
   #   5) Copy any necessary local scripts or files and ensure proper permissions
   image:
     name: ghcr.io/llnl/reproducible-benchmarking-spawn
-    tag: "escience-2025"
+    tag: "hpcic-2025"
     pullPolicy: Always
   # Specify the minimum (i.e., guarantee) and maximum (i.e., limit) amount of resources per user
   cpu:
@@ -106,7 +106,7 @@ singleuser:
   #    chown -R 1000 /home/jovyan
   initContainers:
     - name: init-tutorial-service
-      image: ghcr.io/llnl/reproducible-benchmarking-init:escience-2025
+      image: ghcr.io/llnl/reproducible-benchmarking-init:hpcic-2025
       command: ["/entrypoint.sh"]
       imagePullPolicy: Always
   storage:


### PR DESCRIPTION
## Description

Pretty self-explanatory PR. It just updates the tags for the images from `escience-2025` back to `hpcic-2025` ahead of the eScience tutorial