### PR TITLE
switch blas from fortran to c libraries

### DIFF
--- a/2025-eScience/docker/Dockerfile.benchpark
+++ b/2025-eScience/docker/Dockerfile.benchpark
@@ -22,8 +22,10 @@ RUN apt-get update && \
     xz-utils \
     zstd \
     bzip2 \
-    liblapack-dev \
-    libblas-dev \
+#    liblapack-dev \
+#    libblas-dev \
+    liblapacke-dev \
+    libcblas-dev \
     && rm -rf /var/lib/apt/lists/*
 
 SHELL [ "/bin/bash", "-c" ]


### PR DESCRIPTION
replace fortran blas libraries with c blas libraries

temporarily add this to eScience infrastructure, but if this works, this change will move to the next iteration of the tutorial infrastructure and eScience infrastructure will be restored