### PR TITLE
cblas library

### DIFF
--- a/2025-eScience/docker/Dockerfile.benchpark
+++ b/2025-eScience/docker/Dockerfile.benchpark
@@ -25,7 +25,7 @@ RUN apt-get update && \
 #    liblapack-dev \
 #    libblas-dev \
     liblapacke-dev \
-    libcblas-dev \
+    libatlas-base-dev \
     && rm -rf /var/lib/apt/lists/*
 
 SHELL [ "/bin/bash", "-c" ]

--- a/github_ci_matrix.json
+++ b/github_ci_matrix.json
@@ -1,9 +1,9 @@
 {
     "tag": [
-        "hpcic-2025"
+        "eScience-2025"
     ],
     "tutorial_dir": [
-        "2025-HPCIC"
+        "2025-eScience"
     ],
     "docker_os": [
         "linux"


### PR DESCRIPTION
Trying alternative cblas: 

libcblas-dev <-- no package named this

Other alternatives:
libatlas-base-dev
libopenblas-dev