### PR TITLE
Riken: move manual caliper install

### DIFF
--- a/2026-RIKEN/docker/Dockerfile.benchpark
+++ b/2026-RIKEN/docker/Dockerfile.benchpark
@@ -32,7 +32,7 @@ USER ${NB_USER}
 
 RUN git clone https://github.com/LLNL/benchpark.git ${HOME}/benchpark && \
     cd ${HOME}/benchpark && \
-    git checkout -b develop-2025-12-11 develop-2025-12-11 && \
+    git checkout -b develop-2025-12-12 develop-2025-12-12 && \
     git submodule update --init --recursive
 
 USER root

--- a/2026-RIKEN/docker/Dockerfile.caliper
+++ b/2026-RIKEN/docker/Dockerfile.caliper
@@ -46,7 +46,7 @@ RUN python3 -m venv /opt/global_py_venv
 RUN . /opt/global_py_venv/bin/activate && \
     python3 -m pip install pybind11
 
-ENV CALI_INSTALL_PREFIX=/usr \
+ENV CALI_INSTALL_PREFIX=${HOME}/Caliper/install \
     GIT_CLONE_STAGING_DIR=/tmp
 
 RUN git clone https://github.com/LLNL/Caliper.git ${GIT_CLONE_STAGING_DIR}/Caliper && \

--- a/2026-RIKEN/docker/Dockerfile.spawn
+++ b/2026-RIKEN/docker/Dockerfile.spawn
@@ -50,7 +50,7 @@ RUN . /opt/global_py_venv/bin/activate && \
 COPY ./tutorial-code/caliper-tutorial/apps /tmp/caliper-tutorial/apps/
 COPY ./tutorial-code/caliper-tutorial/cmake /tmp/caliper-tutorial/cmake/
 
-ENV CALI_TUTORIAL_INSTALL_PREFIX=/usr
+ENV CALI_TUTORIAL_INSTALL_PREFIX=${HOME}/Caliper/install
 
 RUN cmake \
     -B /tmp/build-basic-example \


### PR DESCRIPTION
Manual caliper install moved to home so as not to conflict with spack-installed caliper in /usr prefix