### PR TITLE
remove non-existent python 3.14 install

### DIFF
--- a/2026-ICS/docker/Dockerfile.benchpark
+++ b/2026-ICS/docker/Dockerfile.benchpark
@@ -25,10 +25,6 @@ RUN apt-get update && \
     libatlas-base-dev \
     gettext \
     libncurses-dev \
-    python3.14 \
-    python3.14-dev \
-    python3.14-pip \
-    python3.14-venv \
     && rm -rf /var/lib/apt/lists/*
 
 SHELL [ "/bin/bash", "-c" ]
@@ -43,7 +39,7 @@ RUN git clone https://github.com/LLNL/benchpark.git ${HOME}/benchpark && \
 USER root
 
 RUN . /opt/global_py_venv/bin/activate && \
-    python3.14 -m pip install -r ${HOME}/benchpark/requirements.txt
+    python3 -m pip install -r ${HOME}/benchpark/requirements.txt
 
 RUN echo 'export PATH=${HOME}/benchpark/bin:$PATH' >> ${HOME}/.bashrc
 


### PR DESCRIPTION
## Description

Place a description of your PR here

## Checklist
- [ ] If creating a new version of the tutorial, create a new directory at the root of the repository with the relevant name
- [ ] Ensure all Docker-related material except for tutorial contents goes in a `docker` subdirectory
- [ ] Update `github_ci_matrix.json` with (1) the tag you will eventually use for the tutorial Docker images (place in the `"tag"` field) and (2) the name of the directory for your version of the tutorial (place in the `"tutorial_dir"` field)